### PR TITLE
Add extension and fix escape making everything green

### DIFF
--- a/grammars/powerquery.cson
+++ b/grammars/powerquery.cson
@@ -1,5 +1,6 @@
 'fileTypes': [
   'powerquery'
+  'mquery'
   'm'
 ]
 'name': 'Power Query (M)'

--- a/grammars/powerquery.cson
+++ b/grammars/powerquery.cson
@@ -45,7 +45,7 @@
     'name': 'string.quoted.double.m'
     'patterns': [
       {
-        'match': '\\\\.'
+        'match': '\\\\[^"]'
         'name': 'constant.character.escape.m'
       }
     ]


### PR DESCRIPTION
* Added .mquery extension for my work.
* `\"` was making everything green in one of my work files because it's being treated as an escape character. Example: `= "abc" & "\" & "def"` for concatenating a directory. But then everything after `"\"` was turned green.